### PR TITLE
Bug Fix

### DIFF
--- a/lib/jobOperations.js
+++ b/lib/jobOperations.js
@@ -4,7 +4,7 @@ const SERVICE = 'Erp.Bo.JobOperSearchSvc';
 
 class JobOperations extends ServiceBase {
   constructor(connection) {
-    super(connection, SERVICE, 'JobOperList', 'OprSeq');
+    super(connection, SERVICE, 'JobOper', 'OprSeq');
   }
 
   list(where, fields, options = {}) {


### PR DESCRIPTION
When the JobOperations class is instantiated it is passing the incorrect dataset name causing an error in serviceBase._getRows at line 146