### PR TITLE
Bug

### DIFF
--- a/lib/laborApproval.js
+++ b/lib/laborApproval.js
@@ -75,7 +75,7 @@ class LaborApproval extends ServiceBase {
     });
     const {EmployeeNum: approvedById, Name: approvedByName} = approvingEmployee;
 
-    let dataset = await this._getRows(whereObject, 100, 0);
+    let dataset = await this._getRows(whereObject, 1000, 0);
     if (dataset.LaborDtl.length) {
       dataset.LaborDtl.forEach(ld => {
         const payrollDate = moment(ld.PayrollDate).format('YYYY-MM-DD');


### PR DESCRIPTION
- With a row limit of 100 LaborDtl records were getting missed and not getting approved
- The whereObject should include more filter options in this case to limit only LaborDtl records where TimeStatus = S